### PR TITLE
Ensure mixin config adding is idempotent 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "dev.isxander.modstitch"
-version = "0.5.12-beta.1"
+version = "0.5.16-unstable"
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "dev.isxander.modstitch"
-version = "0.5.16-unstable"
+version = "0.5.12-beta.1"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/dev/isxander/modstitch/base/loom/FMJAppendMixinDataTask.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/loom/FMJAppendMixinDataTask.kt
@@ -14,11 +14,11 @@ abstract class FMJAppendMixinDataTask : AppendMixinDataTask() {
 
         val json = gson.fromJson(contents, JsonObject::class.java)
         val mixins = json.getAsJsonArray("mixins") ?: JsonArray().also { json.add("mixins", it) }
-        // ensure idempotentness
         val existingConfigs = mixins.map { it.asJsonObject.get("config").asString }.toSet()
 
         mixinConfigs.get().forEach {
             val obj = JsonObject()
+            // ensure idempotentness
             if (existingConfigs.contains(it.config)) {
                 return@forEach
             }

--- a/src/main/kotlin/dev/isxander/modstitch/base/loom/FMJAppendMixinDataTask.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/loom/FMJAppendMixinDataTask.kt
@@ -14,9 +14,14 @@ abstract class FMJAppendMixinDataTask : AppendMixinDataTask() {
 
         val json = gson.fromJson(contents, JsonObject::class.java)
         val mixins = json.getAsJsonArray("mixins") ?: JsonArray().also { json.add("mixins", it) }
+        // ensure idempotentness
+        val existingConfigs = mixins.map { it.asJsonObject.get("config").asString }.toSet()
 
         mixinConfigs.get().forEach {
             val obj = JsonObject()
+            if (existingConfigs.contains(it.config)) {
+                return@forEach
+            }
             obj.addProperty("config", it.config)
             obj.addProperty("environment", when (it.side) {
                 Side.Both -> "*"

--- a/src/main/kotlin/dev/isxander/modstitch/base/moddevgradle/ModsTomlAppendMixinDataTask.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/moddevgradle/ModsTomlAppendMixinDataTask.kt
@@ -16,7 +16,7 @@ abstract class ModsTomlAppendMixinDataTask : AppendMixinDataTask() {
             config.set<MutableList<Config>>("mixins", newList)
             newList
         }
-        val existingMixins = mixins.map { it.get<String>("config") }.toSet()
+        val existingConfigs = mixins.map { it.get<String>("config") }.toSet()
 
         mixinConfigs.get().forEach {
             if (it.side != Side.Both) {
@@ -24,7 +24,7 @@ abstract class ModsTomlAppendMixinDataTask : AppendMixinDataTask() {
             }
 
             // ensure idempotentness
-            if (existingMixins.contains(it.config)) {
+            if (existingConfigs.contains(it.config)) {
                 return@forEach
             }
 


### PR DESCRIPTION
in 0.5.12 (stable) I noticed how every other run would fail because of duplicate mixin configs, in your unstable versions you fixed this by ignoring the list from the config but this is not ideal as fmj-defined mixin configs would be ignored which would be unexpected behaviour. 

Instead an idempotent task would be more suitable so even if the cached values are fed into the task, no change is made, while still allowing for existing configs to be properly considered.