### PR TITLE
Fix support for Legacy Forge

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4G
 
 deps.loom=1.10.5
-deps.moddevgradle=2.0.80
+deps.moddevgradle=2.0.95
 deps.mpp=0.8.4
 deps.shadow=8.3.6


### PR DESCRIPTION
The current version of Modstitch references a version of ModDevGradle that had a bug, which made it impossible to target Forge versions such as 1.20, 1.19, or 1.18. However, this issue has just been fixed in MDG v2.0.95, hence the bump.

Fixes #6