### PR TITLE
[Fix] `configureObfuscation` is never run when it's supposed to

### DIFF
--- a/src/main/kotlin/dev/isxander/modstitch/base/moddevgradle/BaseModdevgradleExtension.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/moddevgradle/BaseModdevgradleExtension.kt
@@ -48,7 +48,7 @@ interface BaseModDevGradleExtension {
 
     /**
      * The underlying platform-specific extension: `mixin`
-     * Accessing this property will throw an exception if the current platform is ModDevGradle Legacy.
+     * Accessing this property will throw an exception if the current platform is not ModDevGradle Legacy.
      */
     val mixinExtension: MixinExtension
     /**
@@ -81,7 +81,7 @@ open class BaseModDevGradleExtensionImpl @Inject constructor(
         if (type == MDGType.Legacy) super.configureMixin(action) else {}
     override val obfuscationExtension: ObfuscationExtension by ExtensionGetter(project)
     override fun configureObfuscation(action: Action<ObfuscationExtension>) =
-        if (type != MDGType.Legacy) super.configureObfuscation(action) else {}
+        if (type == MDGType.Legacy) super.configureObfuscation(action) else {}
 
     override fun defaultRuns(client: Boolean, server: Boolean, namingConvention: (String) -> String) {
         val project = project


### PR DESCRIPTION
Both `ObfuscationExtension` and `MixinExtension` are intended to be used with MDG Legacy. However, there is currently some confusion in the code regarding the these two, which results in `configureObfuscation` not being executed when it should be and vice versa. This PR resolves the issue.