### PR TITLE
Handle flat mixins in `fabric.mod.json` properly

### DIFF
--- a/src/main/kotlin/dev/isxander/modstitch/base/loom/FMJAppendMixinDataTask.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/loom/FMJAppendMixinDataTask.kt
@@ -14,7 +14,11 @@ abstract class FMJAppendMixinDataTask : AppendMixinDataTask() {
 
         val json = gson.fromJson(contents, JsonObject::class.java)
         val mixins = json.getAsJsonArray("mixins") ?: JsonArray().also { json.add("mixins", it) }
-        val existingConfigs = mixins.map { it.asJsonObject.get("config").asString }.toSet()
+        val existingConfigs = mixins.map { when {
+            it.isJsonObject -> it.asJsonObject.get("config").asString
+            it.isJsonPrimitive && it.asJsonPrimitive.isString -> it.asString
+            else -> ""
+        }}
 
         mixinConfigs.get().forEach {
             val obj = JsonObject()


### PR DESCRIPTION
This PR fixes a bug introduced in #5 that caused Modstitch to halt the entire build chain by throwing an `IllegalStateException` whenever it encountered a `fabric.mod.json` file with mixins defined as strings instead of objects:

```json
"mixins": [
  "foo.mixins.json"
]
```

P.S. - `.toSet()` was removed intentionally, as List's O(n) `contains` is faster and more memory-efficient for the 1-2 entries usually defined by an average mod, compared to creating an entire new set just to leverage its O(1) `contains` once or twice.